### PR TITLE
Added auto switch back like described in issue #59

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,9 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+        <receiver
+            android:name=".service.RevertReceiver"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".PrivateDNSApp"

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/DnsTileService.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/DnsTileService.kt
@@ -253,27 +253,9 @@ class DnsTileService : TileService() {
         tile.label = label
         tile.state = state
         tile.icon = Icon.createWithResource(this, icon)
-        // If auto-revert enabled and user is turning DNS off, schedule revert
-        try {
-            val autoRevertEnabled = sharedPreferences.autoRevertEnabled
-            if (autoRevertEnabled && dnsMode.equals(DNS_MODE_OFF, ignoreCase = true)) {
-                // Save current system mode/provider to preferences
-                val currentMode = PrivateDNSUtils.getPrivateMode(contentResolver)
-                val currentProvider = PrivateDNSUtils.getPrivateProvider(contentResolver)
-                sharedPreferences.revertMode = currentMode
-                sharedPreferences.revertProvider = currentProvider
-                // Schedule revert
-                val minutes = sharedPreferences.autoRevertMinutes
-                RevertScheduler.scheduleRevert(this, minutes)
-            } else if (!dnsMode.equals(DNS_MODE_OFF, ignoreCase = true)) {
-                // If switching back to some non-off state, cancel scheduled revert
-                RevertScheduler.cancelRevert(this)
-                sharedPreferences.revertMode = null
-                sharedPreferences.revertProvider = null
-            }
-        } catch (e: Exception) {
-            // swallow scheduling errors; still attempt to set DNS
-        }
+        
+        // Schedule auto-revert if enabled
+        PrivateDNSUtils.scheduleAutoRevertIfEnabled(this, contentResolver, sharedPreferences, dnsMode, dnsProvider)
 
         PrivateDNSUtils.setPrivateMode(contentResolver, dnsMode)
         PrivateDNSUtils.setPrivateProvider(contentResolver, dnsProvider)

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertReceiver.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertReceiver.kt
@@ -10,25 +10,77 @@ import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertProvider
 import ru.karasevm.privatednstoggle.util.PrivateDNSUtils
 import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertScheduledAt
 import android.widget.Toast
+import android.app.NotificationManager
+import android.app.NotificationChannel
+import androidx.core.app.NotificationCompat
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class RevertReceiver : BroadcastReceiver() {
     companion object {
         private const val TAG = "RevertReceiver"
     }
 
+    private fun writeDebugLog(context: Context, message: String) {
+        try {
+            val logFile = File(context.cacheDir, "revert_debug.log")
+            val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            val line = "[$timestamp] $message\n"
+            logFile.appendText(line)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write debug log: ${e.message}")
+        }
+    }
+
+    private fun showNotification(context: Context, message: String) {
+        try {
+            val channelId = "revert_debug"
+            val notificationId = 12345
+
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+            // Create notification channel for Android 8+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(channelId, "Revert Debug", NotificationManager.IMPORTANCE_HIGH)
+                notificationManager.createNotificationChannel(channel)
+            }
+
+            val notification = NotificationCompat.Builder(context, channelId)
+                .setContentTitle("DNS Revert")
+                .setContentText(message)
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
+                .build()
+
+            notificationManager.notify(notificationId, notification)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to show notification: ${e.message}")
+        }
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
-        Log.d(TAG, "onReceive: revert alarm fired")
+        Log.d(TAG, "onReceive: revert alarm fired - ENTERING BROADCAST RECEIVER")
+        writeDebugLog(context, "onReceive: revert alarm fired - ENTERING BROADCAST RECEIVER")
+
         val prefs = PreferenceHelper.defaultPreference(context)
         val mode = prefs.revertMode
         val provider = prefs.revertProvider
         val scheduledAt = prefs.revertScheduledAt
 
-        Log.d(TAG, "onReceive: stored revert mode=$mode provider=$provider scheduledAt=$scheduledAt now=${System.currentTimeMillis()}")
+        val logMsg = "onReceive: stored revert mode=$mode provider=$provider scheduledAt=$scheduledAt now=${System.currentTimeMillis()}"
+        Log.d(TAG, logMsg)
+        writeDebugLog(context, logMsg)
 
         if (mode.isNullOrBlank()) {
             Log.d(TAG, "onReceive: nothing to revert")
+            writeDebugLog(context, "onReceive: nothing to revert - returning")
             return
         }
+
+        writeDebugLog(context, "onReceive: applying revert to mode=$mode")
 
         // Apply provider first if private
         if (mode.equals(PrivateDNSUtils.DNS_MODE_PRIVATE, true)) {
@@ -40,10 +92,14 @@ class RevertReceiver : BroadcastReceiver() {
 
         PrivateDNSUtils.setPrivateMode(context.contentResolver, mode)
 
-        // Notify user for debugging so we can confirm revert fired
+        val revertMsg = "Private DNS reverted to $mode"
+
+        // Show notification (persistent & visible)
+        showNotification(context, revertMsg)
+
+        // Notify user via toast for debugging
         try {
-            val message = "Private DNS reverted to ${mode ?: "(null)"}"
-            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            Toast.makeText(context, revertMsg, Toast.LENGTH_LONG).show()
         } catch (e: Exception) {
             Log.w(TAG, "onReceive: failed to show toast: ${e.message}")
         }
@@ -52,6 +108,8 @@ class RevertReceiver : BroadcastReceiver() {
         prefs.revertMode = null
         prefs.revertProvider = null
 
-        Log.d(TAG, "onReceive: reverted to mode=$mode provider=$provider")
+        val finalMsg = "onReceive: reverted to mode=$mode provider=$provider"
+        Log.d(TAG, finalMsg)
+        writeDebugLog(context, finalMsg)
     }
 }

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertReceiver.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertReceiver.kt
@@ -1,0 +1,57 @@
+package ru.karasevm.privatednstoggle.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import ru.karasevm.privatednstoggle.util.PreferenceHelper
+import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertMode
+import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertProvider
+import ru.karasevm.privatednstoggle.util.PrivateDNSUtils
+import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertScheduledAt
+import android.widget.Toast
+
+class RevertReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "RevertReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "onReceive: revert alarm fired")
+        val prefs = PreferenceHelper.defaultPreference(context)
+        val mode = prefs.revertMode
+        val provider = prefs.revertProvider
+        val scheduledAt = prefs.revertScheduledAt
+
+        Log.d(TAG, "onReceive: stored revert mode=$mode provider=$provider scheduledAt=$scheduledAt now=${System.currentTimeMillis()}")
+
+        if (mode.isNullOrBlank()) {
+            Log.d(TAG, "onReceive: nothing to revert")
+            return
+        }
+
+        // Apply provider first if private
+        if (mode.equals(PrivateDNSUtils.DNS_MODE_PRIVATE, true)) {
+            PrivateDNSUtils.setPrivateProvider(context.contentResolver, if (provider.isNullOrBlank()) null else provider)
+        } else {
+            // when reverting to non-private, preserve provider value
+            PrivateDNSUtils.setPrivateProvider(context.contentResolver, provider)
+        }
+
+        PrivateDNSUtils.setPrivateMode(context.contentResolver, mode)
+
+        // Notify user for debugging so we can confirm revert fired
+        try {
+            val message = "Private DNS reverted to ${mode ?: "(null)"}"
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+        } catch (e: Exception) {
+            Log.w(TAG, "onReceive: failed to show toast: ${e.message}")
+        }
+
+        // clear saved revert info
+        prefs.revertMode = null
+        prefs.revertProvider = null
+
+        Log.d(TAG, "onReceive: reverted to mode=$mode provider=$provider")
+    }
+}

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertReceiver.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertReceiver.kt
@@ -13,25 +13,11 @@ import android.widget.Toast
 import android.app.NotificationManager
 import android.app.NotificationChannel
 import androidx.core.app.NotificationCompat
-import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+
 
 class RevertReceiver : BroadcastReceiver() {
     companion object {
         private const val TAG = "RevertReceiver"
-    }
-
-    private fun writeDebugLog(context: Context, message: String) {
-        try {
-            val logFile = File(context.cacheDir, "revert_debug.log")
-            val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
-            val line = "[$timestamp] $message\n"
-            logFile.appendText(line)
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to write debug log: ${e.message}")
-        }
     }
 
     private fun showNotification(context: Context, message: String) {
@@ -63,7 +49,6 @@ class RevertReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d(TAG, "onReceive: revert alarm fired - ENTERING BROADCAST RECEIVER")
-        writeDebugLog(context, "onReceive: revert alarm fired - ENTERING BROADCAST RECEIVER")
 
         val prefs = PreferenceHelper.defaultPreference(context)
         val mode = prefs.revertMode
@@ -72,15 +57,11 @@ class RevertReceiver : BroadcastReceiver() {
 
         val logMsg = "onReceive: stored revert mode=$mode provider=$provider scheduledAt=$scheduledAt now=${System.currentTimeMillis()}"
         Log.d(TAG, logMsg)
-        writeDebugLog(context, logMsg)
 
         if (mode.isNullOrBlank()) {
             Log.d(TAG, "onReceive: nothing to revert")
-            writeDebugLog(context, "onReceive: nothing to revert - returning")
             return
         }
-
-        writeDebugLog(context, "onReceive: applying revert to mode=$mode")
 
         // Apply provider first if private
         if (mode.equals(PrivateDNSUtils.DNS_MODE_PRIVATE, true)) {
@@ -110,6 +91,5 @@ class RevertReceiver : BroadcastReceiver() {
 
         val finalMsg = "onReceive: reverted to mode=$mode provider=$provider"
         Log.d(TAG, finalMsg)
-        writeDebugLog(context, finalMsg)
     }
 }

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertScheduler.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertScheduler.kt
@@ -9,12 +9,32 @@ import ru.karasevm.privatednstoggle.util.PreferenceHelper
 import java.util.concurrent.TimeUnit
 import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertScheduledAt
 import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 object RevertScheduler {
+    private const val TAG = "RevertScheduler"
     private const val ACTION_REVERT = "ru.karasevm.privatednstoggle.ACTION_REVERT"
+
+    private fun writeDebugLog(context: Context, message: String) {
+        try {
+            val logFile = File(context.cacheDir, "revert_scheduler.log")
+            val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
+            val line = "[$timestamp] $message\n"
+            logFile.appendText(line)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write debug log: ${e.message}")
+        }
+    }
 
     fun scheduleRevert(context: Context, minutes: Int) {
         val prefs = PreferenceHelper.defaultPreference(context)
+
+        val logMsg1 = "scheduleRevert: CALLED with minutes=$minutes"
+        Log.d(TAG, logMsg1)
+        writeDebugLog(context, logMsg1)
 
         // Build intent to fire our RevertReceiver
         val intent = Intent(context, RevertReceiver::class.java).apply {
@@ -33,15 +53,36 @@ object RevertScheduler {
 
         // Use elapsed realtime + minutes
         val triggerAt = SystemClock.elapsedRealtime() + TimeUnit.MINUTES.toMillis(minutes.toLong())
+        val triggerAtWall = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(minutes.toLong())
 
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pending)
+        val logMsg2 = "scheduleRevert: setting alarm triggerAt(elapsed)=$triggerAt triggerAt(wall)=$triggerAtWall"
+        Log.d(TAG, logMsg2)
+        writeDebugLog(context, logMsg2)
+
+        try {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pending)
+            
+            val logMsg3 = "scheduleRevert: alarm SET SUCCESSFULLY"
+            Log.d(TAG, logMsg3)
+            writeDebugLog(context, logMsg3)
+        } catch (e: Exception) {
+            val logMsg3 = "scheduleRevert: ERROR setting alarm: ${e.message}"
+            Log.e(TAG, logMsg3)
+            writeDebugLog(context, logMsg3)
+        }
 
         // Persist scheduled time for debugging
-        prefs.revertScheduledAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(minutes.toLong())
-        Log.d("RevertScheduler", "scheduleRevert: scheduled in $minutes minute(s), triggerAt(elapsed)=$triggerAt, scheduled_at=${prefs.revertScheduledAt}")
+        prefs.revertScheduledAt = triggerAtWall
+        val logMsg4 = "scheduleRevert: persisted scheduled_at=$triggerAtWall"
+        Log.d(TAG, logMsg4)
+        writeDebugLog(context, logMsg4)
     }
 
     fun cancelRevert(context: Context) {
+        val logMsg1 = "cancelRevert: CALLED"
+        Log.d(TAG, logMsg1)
+        writeDebugLog(context, logMsg1)
+
         val intent = Intent(context, RevertReceiver::class.java).apply {
             action = ACTION_REVERT
             setPackage(context.packageName)
@@ -56,6 +97,8 @@ object RevertScheduler {
         alarmManager.cancel(pending)
         val prefs = PreferenceHelper.defaultPreference(context)
         prefs.revertScheduledAt = 0L
-        Log.d("RevertScheduler", "cancelRevert: cancelled pending revert")
+        val logMsg2 = "cancelRevert: CANCELLED pending revert"
+        Log.d(TAG, logMsg2)
+        writeDebugLog(context, logMsg2)
     }
 }

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertScheduler.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertScheduler.kt
@@ -1,0 +1,61 @@
+package ru.karasevm.privatednstoggle.service
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import ru.karasevm.privatednstoggle.util.PreferenceHelper
+import java.util.concurrent.TimeUnit
+import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertScheduledAt
+import android.util.Log
+
+object RevertScheduler {
+    private const val ACTION_REVERT = "ru.karasevm.privatednstoggle.ACTION_REVERT"
+
+    fun scheduleRevert(context: Context, minutes: Int) {
+        val prefs = PreferenceHelper.defaultPreference(context)
+
+        // Build intent to fire our RevertReceiver
+        val intent = Intent(context, RevertReceiver::class.java).apply {
+            action = ACTION_REVERT
+            setPackage(context.packageName)
+        }
+
+        val pending = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        // Use elapsed realtime + minutes
+        val triggerAt = SystemClock.elapsedRealtime() + TimeUnit.MINUTES.toMillis(minutes.toLong())
+
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pending)
+
+        // Persist scheduled time for debugging
+        prefs.revertScheduledAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(minutes.toLong())
+        Log.d("RevertScheduler", "scheduleRevert: scheduled in $minutes minute(s), triggerAt(elapsed)=$triggerAt, scheduled_at=${prefs.revertScheduledAt}")
+    }
+
+    fun cancelRevert(context: Context) {
+        val intent = Intent(context, RevertReceiver::class.java).apply {
+            action = ACTION_REVERT
+            setPackage(context.packageName)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pending)
+        val prefs = PreferenceHelper.defaultPreference(context)
+        prefs.revertScheduledAt = 0L
+        Log.d("RevertScheduler", "cancelRevert: cancelled pending revert")
+    }
+}

--- a/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertScheduler.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/service/RevertScheduler.kt
@@ -9,32 +9,16 @@ import ru.karasevm.privatednstoggle.util.PreferenceHelper
 import java.util.concurrent.TimeUnit
 import ru.karasevm.privatednstoggle.util.PreferenceHelper.revertScheduledAt
 import android.util.Log
-import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 object RevertScheduler {
     private const val TAG = "RevertScheduler"
     private const val ACTION_REVERT = "ru.karasevm.privatednstoggle.ACTION_REVERT"
-
-    private fun writeDebugLog(context: Context, message: String) {
-        try {
-            val logFile = File(context.cacheDir, "revert_scheduler.log")
-            val timestamp = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date())
-            val line = "[$timestamp] $message\n"
-            logFile.appendText(line)
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to write debug log: ${e.message}")
-        }
-    }
 
     fun scheduleRevert(context: Context, minutes: Int) {
         val prefs = PreferenceHelper.defaultPreference(context)
 
         val logMsg1 = "scheduleRevert: CALLED with minutes=$minutes"
         Log.d(TAG, logMsg1)
-        writeDebugLog(context, logMsg1)
 
         // Build intent to fire our RevertReceiver
         val intent = Intent(context, RevertReceiver::class.java).apply {
@@ -57,31 +41,26 @@ object RevertScheduler {
 
         val logMsg2 = "scheduleRevert: setting alarm triggerAt(elapsed)=$triggerAt triggerAt(wall)=$triggerAtWall"
         Log.d(TAG, logMsg2)
-        writeDebugLog(context, logMsg2)
 
         try {
             alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pending)
             
             val logMsg3 = "scheduleRevert: alarm SET SUCCESSFULLY"
             Log.d(TAG, logMsg3)
-            writeDebugLog(context, logMsg3)
         } catch (e: Exception) {
             val logMsg3 = "scheduleRevert: ERROR setting alarm: ${e.message}"
             Log.e(TAG, logMsg3)
-            writeDebugLog(context, logMsg3)
         }
 
         // Persist scheduled time for debugging
         prefs.revertScheduledAt = triggerAtWall
         val logMsg4 = "scheduleRevert: persisted scheduled_at=$triggerAtWall"
         Log.d(TAG, logMsg4)
-        writeDebugLog(context, logMsg4)
     }
 
     fun cancelRevert(context: Context) {
         val logMsg1 = "cancelRevert: CALLED"
         Log.d(TAG, logMsg1)
-        writeDebugLog(context, logMsg1)
 
         val intent = Intent(context, RevertReceiver::class.java).apply {
             action = ACTION_REVERT
@@ -99,6 +78,5 @@ object RevertScheduler {
         prefs.revertScheduledAt = 0L
         val logMsg2 = "cancelRevert: CANCELLED pending revert"
         Log.d(TAG, logMsg2)
-        writeDebugLog(context, logMsg2)
     }
 }

--- a/app/src/main/java/ru/karasevm/privatednstoggle/ui/DNSServerDialogFragment.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/ui/DNSServerDialogFragment.kt
@@ -18,6 +18,7 @@ import ru.karasevm.privatednstoggle.databinding.SheetDnsSelectorBinding
 import ru.karasevm.privatednstoggle.model.DnsServer
 import ru.karasevm.privatednstoggle.util.PrivateDNSUtils
 import ru.karasevm.privatednstoggle.util.PrivateDNSUtils.checkForPermission
+import ru.karasevm.privatednstoggle.util.PreferenceHelper
 
 class DNSServerDialogFragment : DialogFragment() {
 
@@ -75,9 +76,15 @@ class DNSServerDialogFragment : DialogFragment() {
             ).show()
             dialog!!.dismiss()
         }
+        val sharedPreferences = PreferenceHelper.defaultPreference(requireContext())
+        
         adapter.onItemClick = { id ->
             when (id) {
                 OFF_ID -> {
+                    PrivateDNSUtils.scheduleAutoRevertIfEnabled(
+                        requireContext(), contentResolver, sharedPreferences,
+                        PrivateDNSUtils.DNS_MODE_OFF, null
+                    )
                     PrivateDNSUtils.setPrivateMode(
                         contentResolver,
                         PrivateDNSUtils.DNS_MODE_OFF
@@ -89,6 +96,10 @@ class DNSServerDialogFragment : DialogFragment() {
                 }
 
                 AUTO_ID -> {
+                    PrivateDNSUtils.scheduleAutoRevertIfEnabled(
+                        requireContext(), contentResolver, sharedPreferences,
+                        PrivateDNSUtils.DNS_MODE_AUTO, null
+                    )
                     PrivateDNSUtils.setPrivateMode(
                         contentResolver,
                         PrivateDNSUtils.DNS_MODE_AUTO
@@ -102,6 +113,10 @@ class DNSServerDialogFragment : DialogFragment() {
                 else -> {
                     lifecycleScope.launch {
                         val server = servers.find { server -> server.id == id }
+                        PrivateDNSUtils.scheduleAutoRevertIfEnabled(
+                            requireContext(), contentResolver, sharedPreferences,
+                            PrivateDNSUtils.DNS_MODE_PRIVATE, server?.server
+                        )
                         PrivateDNSUtils.setPrivateMode(
                             contentResolver,
                             PrivateDNSUtils.DNS_MODE_PRIVATE

--- a/app/src/main/java/ru/karasevm/privatednstoggle/ui/OptionsDialogFragment.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/ui/OptionsDialogFragment.kt
@@ -9,6 +9,8 @@ import ru.karasevm.privatednstoggle.databinding.DialogOptionsBinding
 import ru.karasevm.privatednstoggle.util.PreferenceHelper
 import ru.karasevm.privatednstoggle.util.PreferenceHelper.autoMode
 import ru.karasevm.privatednstoggle.util.PreferenceHelper.requireUnlock
+import ru.karasevm.privatednstoggle.util.PreferenceHelper.autoRevertEnabled
+import ru.karasevm.privatednstoggle.util.PreferenceHelper.autoRevertMinutes
 import ru.karasevm.privatednstoggle.util.PrivateDNSUtils
 
 class OptionsDialogFragment : DialogFragment() {
@@ -58,6 +60,23 @@ class OptionsDialogFragment : DialogFragment() {
         binding.requireUnlockSwitch.isChecked = requireUnlock
         binding.requireUnlockSwitch.setOnCheckedChangeListener { _, isChecked ->
             sharedPreferences.requireUnlock = isChecked
+        }
+
+        val autoRevertEnabled = sharedPreferences.autoRevertEnabled
+        binding.autoRevertSwitch.isChecked = autoRevertEnabled
+        binding.autoRevertSwitch.setOnCheckedChangeListener { _, isChecked ->
+            sharedPreferences.autoRevertEnabled = isChecked
+        }
+
+        val minutes = sharedPreferences.autoRevertMinutes
+        binding.autoRevertMinutesInput.setText(minutes.toString())
+        binding.autoRevertMinutesInput.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) {
+                val text = binding.autoRevertMinutesInput.text?.toString() ?: ""
+                val value = text.toIntOrNull() ?: minutes
+                sharedPreferences.autoRevertMinutes = if (value <= 0) 1 else value
+                binding.autoRevertMinutesInput.setText(sharedPreferences.autoRevertMinutes.toString())
+            }
         }
     }
 }

--- a/app/src/main/java/ru/karasevm/privatednstoggle/ui/OptionsDialogFragment.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/ui/OptionsDialogFragment.kt
@@ -74,9 +74,17 @@ class OptionsDialogFragment : DialogFragment() {
             if (!hasFocus) {
                 val text = binding.autoRevertMinutesInput.text?.toString() ?: ""
                 val value = text.toIntOrNull() ?: minutes
-                sharedPreferences.autoRevertMinutes = if (value <= 0) 1 else value
-                binding.autoRevertMinutesInput.setText(sharedPreferences.autoRevertMinutes.toString())
+                val finalValue = if (value <= 0) 1 else value
+                sharedPreferences.autoRevertMinutes = finalValue
+                binding.autoRevertMinutesInput.setText(finalValue.toString())
             }
+        }
+        // Also save on dialog dismiss to catch any pending edits
+        dialog?.setOnDismissListener {
+            val text = binding.autoRevertMinutesInput.text?.toString() ?: ""
+            val value = text.toIntOrNull() ?: minutes
+            val finalValue = if (value <= 0) 1 else value
+            sharedPreferences.autoRevertMinutes = finalValue
         }
     }
 }

--- a/app/src/main/java/ru/karasevm/privatednstoggle/util/SharedPrefUtils.kt
+++ b/app/src/main/java/ru/karasevm/privatednstoggle/util/SharedPrefUtils.kt
@@ -9,6 +9,11 @@ object PreferenceHelper {
     const val DNS_SERVERS = "dns_servers"
     const val AUTO_MODE = "auto_mode"
     const val REQUIRE_UNLOCK = "require_unlock"
+    const val AUTO_REVERT_ENABLED = "auto_revert_enabled"
+    const val AUTO_REVERT_MINUTES = "auto_revert_minutes"
+    const val REVERT_MODE = "revert_mode"
+    const val REVERT_PROVIDER = "revert_provider"
+    const val REVERT_SCHEDULED_AT = "revert_scheduled_at"
 
     fun defaultPreference(context: Context): SharedPreferences =
         context.getSharedPreferences("app_prefs", 0)
@@ -45,6 +50,46 @@ object PreferenceHelper {
         set(value) {
             editMe {
                 it.put(AUTO_MODE to value)
+            }
+        }
+
+    var SharedPreferences.autoRevertEnabled
+        get() = getBoolean(AUTO_REVERT_ENABLED, false)
+        set(value) {
+            editMe {
+                it.put(AUTO_REVERT_ENABLED to value)
+            }
+        }
+
+    var SharedPreferences.autoRevertMinutes
+        get() = getInt(AUTO_REVERT_MINUTES, 5)
+        set(value) {
+            editMe {
+                it.put(AUTO_REVERT_MINUTES to value)
+            }
+        }
+
+    var SharedPreferences.revertMode
+        get() = getString(REVERT_MODE, null)
+        set(value) {
+            editMe {
+                it.put(REVERT_MODE to (value ?: ""))
+            }
+        }
+
+    var SharedPreferences.revertProvider
+        get() = getString(REVERT_PROVIDER, null)
+        set(value) {
+            editMe {
+                it.put(REVERT_PROVIDER to (value ?: ""))
+            }
+        }
+
+    var SharedPreferences.revertScheduledAt
+        get() = getLong(REVERT_SCHEDULED_AT, 0L)
+        set(value) {
+            editMe {
+                it.put(REVERT_SCHEDULED_AT to value)
             }
         }
 

--- a/app/src/main/res/layout/dialog_options.xml
+++ b/app/src/main/res/layout/dialog_options.xml
@@ -62,4 +62,46 @@
         android:text="@string/require_unlock_setting"
         android:textSize="16sp" />
 
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/autoRevertSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:maxWidth="320dp"
+        android:text="@string/auto_revert_enable"
+        android:textSize="16sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="@string/auto_revert_duration_label"
+            android:textSize="14sp" />
+
+        <EditText
+            android:id="@+id/autoRevertMinutesInput"
+            android:layout_width="64dp"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:ems="4"
+            android:gravity="end"
+            android:text="5" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/minutes_short" />
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,9 @@
     <string name="set_to_auto_toast">Private DNS set to auto</string>
     <string name="set_to_provider_toast">Private DNS set to %1$s</string>
     <string name="require_unlock_setting">Require unlocking the device to change server</string>
+    <string name="auto_revert_enable">Auto-revert to previous DNS after timeout</string>
+    <string name="auto_revert_duration_label">Revert after</string>
+    <string name="minutes_short">min</string>
     <string name="a11y_drag_handle">Drag handle</string>
     <string name="menu_import">Import</string>
     <string name="menu_export">Export</string>


### PR DESCRIPTION
Implemented setting toggle to choose if DNS should auto revert to setting set when toggling this setting (described in #59). Including a custom timeout/switchback time. Default at 5 minutes, also verified with 1 minute. This works either from private dns to auto, auto to off off to private dns or auto to private dns and back. In all cases it will revert to the DNS when you switched the setting on.
Depending on user feedback the settings behind this logic can be adjusted but this lays at least the framework and for most use cases this will likely already be enough. Maybe some context should be added to explain that it works like described as it could otherwise be misinterpreted for a new user.
